### PR TITLE
「point808. com」追加(github 転載サイト)

### DIFF
--- a/src/Host.hs
+++ b/src/Host.hs
@@ -87,6 +87,7 @@ living-sun.com
 nobis.work
 ojit.com
 overcoder.net
+point808.com
 progi.pro
 programmerstart.com
 programmerz.ru

--- a/uBlacklist.txt
+++ b/uBlacklist.txt
@@ -66,6 +66,7 @@
 *://*.nobis.work/*
 *://*.ojit.com/*
 *://*.overcoder.net/*
+*://*.point808.com/*
 *://*.progi.pro/*
 *://*.programmerstart.com/*
 *://*.programmerz.ru/*


### PR DESCRIPTION
> githubの転載と思われるサイトを発見しました為、ご報告させていただきます。
> (理由: ページランク上位(5位)にヒットしている為)
> WHOIS検索結果を見る限り、2021年6月30日頃に取得されたドメインの模様です。
> `Updated Date: 2021-06-30T03:15:52Z`
> 証拠
> https://www.google.com/search?q=site%3Apoint808.com
> https://www.google.com/search?q=phpstan+SplFixedArray (git.point808 .com)
> #2