### PR TITLE
「newbedev.com」を追加

### DIFF
--- a/src/Host.hs
+++ b/src/Host.hs
@@ -87,6 +87,7 @@ kotaeta.com
 laptrinhx.com
 legkovopros.ru
 living-sun.com
+newbedev.com
 nobis.work
 ojit.com
 overcoder.net

--- a/uBlacklist.txt
+++ b/uBlacklist.txt
@@ -66,6 +66,7 @@
 *://*.laptrinhx.com/*
 *://*.legkovopros.ru/*
 *://*.living-sun.com/*
+*://*.newbedev.com/*
 *://*.nobis.work/*
 *://*.ojit.com/*
 *://*.overcoder.net/*


### PR DESCRIPTION
主に https://serverfault.com/ のコピーを行っているサイトを発見しましたので、ご報告させていただきます。

newbedev.com にあるタイトルを検索すると serverfault.com のページが出るかと思います。

例:
https://newbedev.com/gitlab-not-working-with-ssh-keys
https://serverfault.com/questions/567340/gitlab-not-working-with-ssh-keys