### PR TITLE
feat: add `docker.jp`

### DIFF
--- a/uBlacklist.txt
+++ b/uBlacklist.txt
@@ -215,6 +215,7 @@ title/^of \/ubuntu/
 *://*.dhaka12.com/*
 *://*.diversitasfp.org/*
 *://*.dominicanhighschool.com/*
+*://*.docker.jp/*
 *://*.e-jinanbo.com/*
 *://*.economiajalisco.cucea.udg.mx/*
 *://*.efeegypt.org/*
@@ -7396,4 +7397,3 @@ title/^of \/ubuntu/
 *://*.coder-solution-zm.org/*
 *://*.coder-solution-zu.org/*
 *://*.coder-solution-zw.org/*
-


### PR DESCRIPTION
Docker の公式ドキュメントを日本語訳したサイト，のようですが5ヶ月前に EoL した Docker 24.0 のバージョンの内容そのままで検索結果の上位 (本家ドキュメントよりも) に存在してしまっているため，検索結果のノイズになっています． (日本語訳... といいつつ原文を読まず破壊的なコマンドなどもそのまま記載している)

GitHub を見ると一応最新版に追随はしているようですが，デプロイがされておらず古いままインターネットに存在してしまっている現状を踏まえ，ブロックです．

* `assert/` 配下のファイルにもホスト名を追加すべきなのでしょうが，適切な場所が見つからなかったので RC で指摘してください