### PR TITLE
build: 参照するnixpkgsをunstableに変更

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -609,7 +609,7 @@
         "haskellNix": "haskellNix",
         "nixpkgs": [
           "haskellNix",
-          "nixpkgs-2511"
+          "nixpkgs-unstable"
         ],
         "treefmt-nix": "treefmt-nix"
       }
@@ -648,8 +648,7 @@
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
-          "haskellNix",
-          "nixpkgs-2511"
+          "nixpkgs"
         ]
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,10 @@
 {
   inputs = {
-    nixpkgs.follows = "haskellNix/nixpkgs-2511";
+    nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
-      inputs = {
-        nixpkgs.follows = "haskellNix/nixpkgs-2511";
-      };
+      inputs.nixpkgs.follows = "nixpkgs";
     };
     haskellNix.url = "github:input-output-hk/haskell.nix";
   };


### PR DESCRIPTION
`haskell.nix`では`unstable`を使ったほうが良い体験ができることが多いので、
変更します。
どちらにせよ`nixpkgs-2605`は`haskell.nix`では公開されていませんし。
