### PR TITLE
build(deps): update ncaq/nix-composite-action to v3

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,5 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-      - uses: ncaq/nix-composite-action@1f61495635078811dbd842fc9d320c4d67380fcf # v2.0.0
-        with:
-          cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - uses: ncaq/nix-composite-action@9b26867355388b589de67c08de87e8786e2e8094 # v3.0.0
       - run: nix flake check


### PR DESCRIPTION
ncaq/nix-composite-actionのv3で`cachix-auth-token`入力が削除され、
Cachixはread-only substituterとしてのみ追加されるようになりました。
書き込みはniks3に一本化されています。

これに伴い、呼び出し側で`cachix-auth-token`を渡している箇所を削除し、
バージョン参照をv3へ更新します。

ref https://github.com/ncaq/nix-composite-action/pull/67
